### PR TITLE
fix(package.json): fix typo in peru-lima script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"No test specified\" && exit 0",
     "dev": "cross-env ENV=dev quasar dev -m electron",
     "build:co": "cross-env ENV=prod FOLDER=co quasar build -m electron",
-    "build:pe": "cross-env ENV=prod FOLDER=pe quasar build -m electron",
+    "build:pl": "cross-env ENV=prod FOLDER=pl quasar build -m electron",
     "build:pt": "cross-env ENV=prod FOLDER=pt quasar build -m electron",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Fixed typo 'pe' to 'pl'